### PR TITLE
Phase 2: implement core models and dealing mechanics

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -67,6 +67,24 @@ This document records generative AI usage for the BIOSTAT 821 final project, as 
 - How output was used/modified:
   workflows were simplified and validated locally with `ruff` and `pytest`.
 
+### Record 5
+- Date: 2026-04-20
+- Task: Implement Phase-2 engine foundation.
+- How AI was used:
+  requested implementation of core models and initial deal/stock logic for
+  one-suit Spider Solitaire, plus acceptance-focused unit tests.
+- What AI produced:
+  created and updated files:
+  - `src/spider_solitaire/engine.py`
+  - `src/spider_solitaire/__init__.py`
+  - `tests/test_engine_phase2.py`
+  and executed validation commands:
+  - `ruff check src tests`
+  - `mypy src tests`
+  - `pytest tests/`
+- How output was used/modified:
+  code was reviewed and lint/type/test issues were corrected before finalizing.
+
 ## Notes
 
 - AI-assisted outputs were reviewed before acceptance.

--- a/src/spider_solitaire/__init__.py
+++ b/src/spider_solitaire/__init__.py
@@ -1,3 +1,27 @@
 """Core package for the simple Spider Solitaire project."""
 
-__all__: list[str] = []
+from .engine import (
+    CARDS_PER_RANK,
+    INITIAL_COLUMN_SIZES,
+    NUM_COLUMNS,
+    ONE_SUIT,
+    Card,
+    GameState,
+    Rank,
+    create_deck,
+    deal_stock,
+    new_game,
+)
+
+__all__ = [
+    "CARDS_PER_RANK",
+    "INITIAL_COLUMN_SIZES",
+    "NUM_COLUMNS",
+    "ONE_SUIT",
+    "Card",
+    "GameState",
+    "Rank",
+    "create_deck",
+    "deal_stock",
+    "new_game",
+]

--- a/src/spider_solitaire/engine.py
+++ b/src/spider_solitaire/engine.py
@@ -1,0 +1,90 @@
+"""Core engine models and setup logic for one-suit Spider Solitaire."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Final
+
+NUM_COLUMNS: Final[int] = 10
+CARDS_PER_RANK: Final[int] = 8
+INITIAL_COLUMN_SIZES: Final[tuple[int, ...]] = (6, 6, 6, 6, 5, 5, 5, 5, 5, 5)
+ONE_SUIT: Final[str] = "S"
+
+
+class Rank(IntEnum):
+    """Card ranks from ace to king."""
+
+    ACE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+    SIX = 6
+    SEVEN = 7
+    EIGHT = 8
+    NINE = 9
+    TEN = 10
+    JACK = 11
+    QUEEN = 12
+    KING = 13
+
+
+@dataclass(slots=True)
+class Card:
+    """A single playing card used by the engine."""
+
+    rank: Rank
+    suit: str = ONE_SUIT
+    face_up: bool = False
+
+
+@dataclass(slots=True)
+class GameState:
+    """Mutable game state for a single Spider Solitaire run."""
+
+    tableau: list[list[Card]]
+    stock: list[Card]
+    completed_sequences: int = 0
+
+
+def create_deck() -> list[Card]:
+    """Create a 104-card one-suit Spider Solitaire deck."""
+    deck: list[Card] = []
+    for _ in range(CARDS_PER_RANK):
+        for rank in Rank:
+            deck.append(Card(rank=rank))
+    return deck
+
+
+def new_game(seed: int | None = None) -> GameState:
+    """Create a new game with shuffled deck and initial deal."""
+    deck = create_deck()
+    random.Random(seed).shuffle(deck)
+    tableau = _deal_initial_tableau(deck)
+    return GameState(tableau=tableau, stock=deck)
+
+
+def deal_stock(state: GameState) -> None:
+    """Deal one face-up stock card to each tableau column."""
+    if len(state.stock) < NUM_COLUMNS:
+        raise ValueError("Not enough cards in stock to deal to all columns.")
+
+    for column in state.tableau:
+        card = state.stock.pop()
+        card.face_up = True
+        column.append(card)
+
+
+def _deal_initial_tableau(deck: list[Card]) -> list[list[Card]]:
+    """Deal cards to the 10 columns using Spider initial layout rules."""
+    tableau: list[list[Card]] = []
+    for column_size in INITIAL_COLUMN_SIZES:
+        column: list[Card] = []
+        for card_index in range(column_size):
+            card = deck.pop()
+            card.face_up = card_index == (column_size - 1)
+            column.append(card)
+        tableau.append(column)
+    return tableau

--- a/tests/test_engine_phase2.py
+++ b/tests/test_engine_phase2.py
@@ -1,0 +1,93 @@
+"""Tests for Phase-2 engine foundation and initial dealing behavior."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from spider_solitaire import (
+    INITIAL_COLUMN_SIZES,
+    NUM_COLUMNS,
+    Card,
+    GameState,
+    Rank,
+    create_deck,
+    deal_stock,
+    new_game,
+)
+
+
+def test_create_deck_has_expected_size_and_rank_distribution() -> None:
+    """Deck should contain 104 one-suit cards with 8 cards per rank."""
+    deck = create_deck()
+
+    assert len(deck) == 104
+    assert all(card.suit == "S" for card in deck)
+
+    rank_counts = Counter(card.rank for card in deck)
+    assert all(rank_counts[rank] == 8 for rank in Rank)
+
+
+def test_new_game_is_reproducible_when_seed_matches() -> None:
+    """The same random seed should produce identical initial state."""
+    state_1 = new_game(seed=2026)
+    state_2 = new_game(seed=2026)
+
+    assert _snapshot_state(state_1) == _snapshot_state(state_2)
+
+
+def test_new_game_initial_tableau_and_stock_counts() -> None:
+    """Initial layout should match Spider's one-suit setup rules."""
+    state = new_game(seed=1)
+
+    column_sizes = [len(column) for column in state.tableau]
+    assert column_sizes == list(INITIAL_COLUMN_SIZES)
+    assert len(state.stock) == 50
+
+
+def test_new_game_only_top_tableau_cards_are_face_up() -> None:
+    """Each tableau column should start with only its top card face up."""
+    state = new_game(seed=7)
+
+    for column in state.tableau:
+        assert all(not card.face_up for card in column[:-1])
+        assert column[-1].face_up
+
+
+def test_deal_stock_adds_one_face_up_card_to_each_column() -> None:
+    """Stock deal should add one face-up card to all 10 columns."""
+    state = new_game(seed=10)
+    previous_sizes = [len(column) for column in state.tableau]
+    previous_stock_size = len(state.stock)
+
+    deal_stock(state)
+
+    assert len(state.stock) == previous_stock_size - NUM_COLUMNS
+    for index, column in enumerate(state.tableau):
+        assert len(column) == previous_sizes[index] + 1
+        assert column[-1].face_up
+
+
+def test_deal_stock_raises_if_fewer_than_ten_cards_remain() -> None:
+    """Dealing stock requires at least one card per tableau column."""
+    state = GameState(tableau=[[] for _ in range(NUM_COLUMNS)], stock=[])
+    state.stock = [Card(rank=Rank.ACE) for _ in range(NUM_COLUMNS - 1)]
+
+    with pytest.raises(ValueError, match="Not enough cards in stock"):
+        deal_stock(state)
+
+
+def _snapshot_state(
+    state: GameState,
+) -> tuple[
+    tuple[tuple[tuple[Rank, bool], ...], ...],
+    tuple[tuple[Rank, bool], ...],
+]:
+    """Convert state into immutable tuples for deterministic comparison."""
+    tableau_view = tuple(
+        tuple((card.rank, card.face_up) for card in column)
+        for column in state.tableau
+    )
+    stock_view = tuple((card.rank, card.face_up) for card in state.stock)
+    return tableau_view, stock_view


### PR DESCRIPTION
- add core engine module with Rank, Card, and GameState models (**Class**, **OOP**)
- implement one-suit 104-card deck construction (8 x A-K)
- implement deterministic new_game(seed) shuffle and initial deal
- implement Spider initial tableau layout (6x4, 5x6)
- enforce initial face-up rule (only top card in each column)
- implement stock dealing to all 10 columns with validation
- export engine API from package __init__
- add phase-2 unit tests for deck/deal/seed/stock behaviors
- update AI usage log for phase-2 development